### PR TITLE
fix: boxSizing 때문에 너비가 100%를 초과하는 문제

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,3 +127,11 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
- width  퍼센트 지정과 패딩을 동시에 적용해서 콘텐츠의 총 너비가 100%가 넘는 문제를 `box-sizing: border-box` 로 해결하였습니다.
- 또한, body에 `overflow-x: hidden` 을 적용하여 바디에 가로 스크롤이 나타나지 않도록 하였습니다.

- [box-sizing 자료](https://juicyjerry.tistory.com/entry/css%EC%97%90%EC%84%9C-box-sizing-%EC%9D%84-border-box%EB%A1%9C-%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0)